### PR TITLE
MASTEM27-Bash script for rebuilding DB

### DIFF
--- a/bin/dev/redo_db.sh
+++ b/bin/dev/redo_db.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+rake db:drop
+rake db:create
+rake db:schema:load
+rake db:migrate
+rake db:seed


### PR DESCRIPTION
I created a bash script for rebuilding the database, located at bin/dev/redo_db.sh. You should be able to run it using `./redo_db.sh` or `sh redo_db.sh`.